### PR TITLE
Add tcsh as a biokepi dependency for netmhc tools

### DIFF
--- a/src/lib/deploy.ml
+++ b/src/lib/deploy.ml
@@ -237,7 +237,7 @@ module Node = struct
             | `Torque_client -> "torque-client torque-mom"
             | `Opam -> "opam m4 pkg-config libgmp-dev"
             | `Sqlite -> "libsqlite3-dev"
-            | `Biokepi_dependencies -> "cmake r-base"
+            | `Biokepi_dependencies -> "cmake r-base tcsh"
             | `Libev -> "libev-dev"
         )
       |> String.concat ~sep:" "


### PR DESCRIPTION
local installations of netMHC tools depend on `tcsh`, so we need this shell on our instances.