### PR TITLE
Fix missing dependency on user creation

### DIFF
--- a/src/lib/deploy.ml
+++ b/src/lib/deploy.ml
@@ -1063,6 +1063,7 @@ module User = struct
       ~name ~make
       ~edges:[
         depends_on (Node.create_instance on ~configuration);
+        depends_on (add t ~on ~configuration);
       ]
 
 end


### PR DESCRIPTION
The `User.authorize_key` function uses `chown` so it requires the user
to exist.